### PR TITLE
kubectl: initial image of kubernetes clients

### DIFF
--- a/kubectl/Dockerfile
+++ b/kubectl/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:3.4
+
+MAINTAINER Clouway Devs <devs@clouway.com>
+
+ENV KUBE_LATEST_VERSION="v1.11.0"
+
+RUN apk add --update ca-certificates \
+ && apk add --update -t deps curl \
+ && apk add --update gettext \
+ && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
+ && chmod +x /usr/local/bin/kubectl \
+ && apk del --purge deps \
+ && rm /var/cache/apk/*

--- a/kubectl/README.md
+++ b/kubectl/README.md
@@ -1,0 +1,5 @@
+## Kubernetes Client Containers
+
+### Versions
+
+ * 1.11 - clouway/kubectl:1.11


### PR DESCRIPTION
Added a Docker image with the kubernetes client installed on it which to be used for remote control of kubernetes clusters.