### PR TITLE
java8: add slim container of openjdk 8 on debian

### DIFF
--- a/java8-slim/Dockerfile
+++ b/java8-slim/Dockerfile
@@ -1,0 +1,13 @@
+FROM openjdk:8-jdk-stretch
+
+MAINTAINER Telcong Dev <telcong@clouway.com>
+
+RUN apt-get update
+RUN cp /usr/share/zoneinfo/Europe/Sofia /etc/localtime
+
+RUN echo "Europe/Sofia" > /etc/timezone
+RUN rm /etc/localtime
+
+RUN apt-get install -y rsync
+
+# EOF


### PR DESCRIPTION
A new java8 container with openjdk installed on debian.