### PR TITLE
java: docker container with pre-installed java 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # docker-containers
 A Set of generic Docker containers 
+
+### Java
+A set of JVM images
+
+#### Versions
+
+ * Java 11 - clouway/java11:jre-alpine
+ * Java 11 - clouway/java11:jdk-alpine
+ * Java 8  - clouway/java:8
+
+### kubectl
+A set of images with pre-installed kubernetes controller
+
+#### Versions 
+ * 1.11 - clouway/kubectl:1.11
+
+

--- a/java11/jdk/Dockerfile
+++ b/java11/jdk/Dockerfile
@@ -1,0 +1,10 @@
+FROM adoptopenjdk/openjdk11:x86_64-alpine-jdk-11.0.4_11-slim 
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN apk update
+RUN apk add tzdata git
+RUN cp /usr/share/zoneinfo/Europe/Sofia /etc/localtime
+
+RUN echo "Europe/Sofia" > /etc/timezone
+RUN rm /etc/localtime

--- a/java11/jdk/Makefile
+++ b/java11/jdk/Makefile
@@ -1,0 +1,5 @@
+build:
+	docker build -t clouway/java11:jdk-alpine .
+
+push:
+	docker push clouway/java11:jdk-alpine

--- a/java11/jre/Dockerfile
+++ b/java11/jre/Dockerfile
@@ -1,0 +1,10 @@
+FROM adoptopenjdk/openjdk11:x86_64-alpine-jre11u-nightly
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN apk update
+RUN apk add tzdata git
+RUN cp /usr/share/zoneinfo/Europe/Sofia /etc/localtime
+
+RUN echo "Europe/Sofia" > /etc/timezone
+RUN rm /etc/localtime

--- a/java11/jre/Makefile
+++ b/java11/jre/Makefile
@@ -1,0 +1,5 @@
+build:
+	docker build -t clouway/java11:jre-alpine .
+
+push:
+	docker push clouway/java11:jre-alpine

--- a/java8/README.md
+++ b/java8/README.md
@@ -1,5 +1,0 @@
-## Java Containers
-
-### Versions
-
- * Java 8 - clouway/java:8

--- a/kubectl/README.md
+++ b/kubectl/README.md
@@ -1,5 +1,0 @@
-## Kubernetes Client Containers
-
-### Versions
-
- * 1.11 - clouway/kubectl:1.11


### PR DESCRIPTION
ADded docker container with pre-installed java 11 which provides better
memory management and performance.

As a side change, the documentation files (README.md) are combined into a single one that specifies the list of all available images and their versions.